### PR TITLE
Added rule for using root relative imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,19 @@ Example usage:
     {name: ["*", "forEach"], message: "Please refactor and use regular loops instead"},
 ],
 ```
+
+## root-relative-imports
+Prevents traversing upwards in directory structure when importing files, forcing the use of root relative imports instead.
+
+Example:
+```js
+import { MyComponent } from './MyComponent'; -> allowed
+import { MyComponent } from './Child/MyComponent'; -> allowed
+import { MyComponent } from 'components/MyComponent'; -> allowed
+import { MyComponent } from '../components/MyComponent'; -> not allowed
+```
+
+Example usage:
+```js
+"root-relative-imports": true,
+```

--- a/agoda-tslint.json
+++ b/agoda-tslint.json
@@ -3,6 +3,7 @@
     "rules": {
         "do-not-use": false,
         "no-mount-and-snapshot": false,
-        "no-set-timeout-in-test": false
+        "no-set-timeout-in-test": false,
+        "root-relative-imports": false
     }
 }

--- a/src/rules/rootRelativeImportsRule.ts
+++ b/src/rules/rootRelativeImportsRule.ts
@@ -1,0 +1,25 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "Use root relative imports";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new ImportWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class ImportWalker extends Lint.RuleWalker {
+    public visitImportDeclaration(node: ts.ImportDeclaration) {
+        if (!ts.isStringLiteral(node.moduleSpecifier)) {
+            return;
+        }
+
+        const source = node.moduleSpecifier.text;
+        if (source.indexOf("../") !== -1) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        }
+
+        super.visitImportDeclaration(node);
+    }
+}


### PR DESCRIPTION
Rule to prevent traversing upwards in the directory tree instead of using root relative imports. Allows relative for same or child folders.

```
import { MyComponent } from './MyComponent'; -> allowed
import { MyComponent } from 'components/MyComponent'; -> allowed
import { MyComponent } from '../components/MyComponent'; -> not allowed
```